### PR TITLE
Fix OpenAI client initialization by pinning httpx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 espn-api
 openai==1.44.1
+httpx<0.28
 pytz
 yfpy==13.0.0
 git+https://github.com/jeisey/sleeper-api-wrapper-commish.git@master#egg=sleeper-api-wrapper


### PR DESCRIPTION
## Summary
- pin httpx<0.28 to resolve TypeError when constructing the OpenAI client

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from openai import OpenAI
client = OpenAI(organization='test', project='test', api_key='test')
print('client created', client)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c19f9354b4832cbd60fd6fc057f757