### PR TITLE
Show stat summaries for all leagues

### DIFF
--- a/app.py
+++ b/app.py
@@ -223,12 +223,14 @@ def main():
                 elif league_type == "Sleeper":
                     auth_directory = "auth"
                     summary = summary_generator.generate_sleeper_summary(
-                        league_id  
+                        league_id
                     )
                     LOGGER.debug(summary)
                     LOGGER.info(f"Generated Sleeper Summary: \n{summary}")
-                    st.write(summary) #to delete
-                
+
+                st.markdown("### Stat Summary")
+                st.markdown(summary)
+
                 progress.text('Generating AI summary...')
                 progress.progress(50)
 


### PR DESCRIPTION
## Summary
- display stat summaries after fetching league data so ESPN leagues no longer miss the stats bullet list

## Testing
- `python -m py_compile app.py utils/summary_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1a3e8ffb0832c9e6c1008aa1efbca