### PR TITLE
Replace deprecated Streamlit image parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,7 +51,7 @@ def main():
 
 
     with st.sidebar:
-        st.sidebar.image('logo.png', use_column_width=True)
+        st.sidebar.image('logo.png', use_container_width=True)
         is_available, today = check_availability()
         if is_available:
             st.success(f"Today is {today}. The most recent week is completed and a recap is available.")


### PR DESCRIPTION
## Summary
- replace deprecated `use_column_width` with `use_container_width` in the sidebar logo image to remove Streamlit warning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a9249140832caf0650f01e54c7d1